### PR TITLE
Add a footer attribution for Blueprint and the USDE Sunshot program.

### DIFF
--- a/revolv/static/css/screen.css
+++ b/revolv/static/css/screen.css
@@ -3501,6 +3501,20 @@ header.edit-project-header > .container > h1 {
   padding: 5px 0 0 0;
 }
 
+/* .footer .attribution */
+
+.footer .attribution {
+  color: #8a8a8a;
+  font-size: 14px;
+  text-align: left;
+  line-height: 24px;
+  padding-bottom: 5px;
+}
+
+.footer .attribution a {
+  color: #14b1e7;
+}
+
 /* .footer .bottoms */
 
 .footer .bottoms {
@@ -5647,6 +5661,7 @@ header.edit-project-header > .container > h1 {
     line-height: 20px;
     padding: 5px 0 0 0;
   }
+
   /* .footer .bottoms */
   .footer .bottoms {
     margin: 0 86px 0 99px;

--- a/revolv/templates/base/partials/foot.html
+++ b/revolv/templates/base/partials/foot.html
@@ -64,6 +64,7 @@
       <!-- end .col-info -->
     </div>
     <!-- end .row -->
+    <div class="row"><p class="attribution">This website was developed with the support of <a href="https://www.calblueprint.org/">Blueprint</a> and the <a href="http://energy.gov/eere/sunshot/about-sunshot-initiative">U.S. Department of Energy Sunshot Initiative</a>.</p></div>
     <div class="bottoms">
       <div class="lefts pull-left">
         <a href="javascript:;" class="logo"></a>


### PR DESCRIPTION
@RE-volv: I've added a footer attribution linking to calblueprint.org and the USDE website as Andreas suggested.

![screen shot 2016-04-07 at 11 07 08 pm](https://cloud.githubusercontent.com/assets/1168853/14375423/175fd130-fd16-11e5-8952-de00f0b39ae2.png)
![screen shot 2016-04-07 at 11 06 58 pm](https://cloud.githubusercontent.com/assets/1168853/14375422/175d62f6-fd16-11e5-8b1f-1526a2244bb2.png)
![screen shot 2016-04-07 at 11 06 37 pm](https://cloud.githubusercontent.com/assets/1168853/14375421/175d635a-fd16-11e5-9088-4f1d4e3589e1.png)
![screen shot 2016-04-07 at 11 06 25 pm](https://cloud.githubusercontent.com/assets/1168853/14375424/17602126-fd16-11e5-955c-3f5dad25be6b.png)
![screen shot 2016-04-07 at 11 04 46 pm](https://cloud.githubusercontent.com/assets/1168853/14375425/17603efe-fd16-11e5-98ce-3800bfc77bac.png)
