### PR TITLE
pin simple-salesforce==0.75

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,7 @@ wagtail==1.0b2
 wagtailsettings==0.4.1
 django-sekizai==0.8.1
 django-sesame==1.1
-simple-salesforce>=0.74.1
+simple-salesforce==0.75
 stripe==1.33.0
 PyYAML==3.11
 six==1.9.0


### PR DESCRIPTION
Python 2.7 support for simple-salesforce was removed in 1.0.0: https://github.com/simple-salesforce/simple-salesforce/blob/master/CHANGES

See also: https://stackoverflow.com/questions/29358403/no-module-named-urllib-parse-how-should-i-install-it

CC @copelco 